### PR TITLE
feat(desktop): simplify macOS drag-install DMG background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+- [2026-03-09 12:10] REFACTOR: DMG 背景改为使用原版 docs/image.png 并叠加 60% 白色蒙版，移除额外 logo 与文案设计 (Files: desktop/build/package_dmg.sh, desktop/build/render_dmg_background.swift, desktop/build/README.md, desktop/README.md)
+- [2026-03-09 12:10] FEAT: DMG 安装窗口改为使用架构图背景、项目 logo 和 README 主文案，并优化拖拽安装图标布局 (Files: desktop/build/package_dmg.sh, desktop/build/render_dmg_background.swift, desktop/build/README.md, desktop/README.md)
+- [2026-03-09 11:59] FEAT: 新增 macOS 拖拽安装 DMG 打包脚本，支持将应用拖入 Applications 安装 (Files: desktop/build/package_dmg.sh, desktop/build/README.md, desktop/README.md)

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -17,3 +17,14 @@ to this in your browser, and you can call your Go code from devtools.
 ## Building
 
 To build a redistributable, production mode package, use `wails build`.
+
+For a macOS drag-install image that lets users drop the app into `Applications`, run:
+
+```bash
+cd desktop
+/tmp/gopath/bin/wails build -clean -platform darwin/amd64 -m -nosyncgomod
+./build/package_dmg.sh
+```
+
+The resulting installer image is written to `build/bin/AIVectorMemory-darwin-amd64.dmg`.
+The DMG window automatically uses `docs/image.png` as the background and applies a 60% white overlay without additional decorative elements.

--- a/desktop/build/README.md
+++ b/desktop/build/README.md
@@ -1,12 +1,12 @@
 # Build Directory
 
-The build directory is used to house all the build files and assets for your application. 
+The build directory is used to house all the build files and assets for your application.
 
 The structure is:
 
-* bin - Output directory
-* darwin - macOS specific files
-* windows - Windows specific files
+* `bin` - Output directory
+* `darwin` - macOS specific files
+* `windows` - Windows specific files
 
 ## Mac
 
@@ -19,6 +19,31 @@ The directory contains the following files:
 
 - `Info.plist` - the main plist file used for Mac builds. It is used when building using `wails build`.
 - `Info.dev.plist` - same as the main plist file but used when building using `wails dev`.
+- `render_dmg_background.swift` - renders the drag-install DMG background from `docs/image.png` with a 60% white overlay.
+
+### Drag-install DMG
+
+To create a macOS DMG that supports dragging the app into `Applications`, first build the app bundle and then run the packaging script:
+
+```bash
+cd desktop
+/tmp/gopath/bin/wails build -clean -platform darwin/amd64 -m -nosyncgomod
+./build/package_dmg.sh
+```
+
+What the packaging script does:
+
+- Copies `AIVectorMemory.app` into a temporary DMG staging folder
+- Adds an `Applications` symlink so users can drag the app into the system Applications folder
+- Uses `docs/image.png` as the base artwork and applies a 60% white overlay for a cleaner drag-install window background
+- Uses Finder layout automation to place the app and `Applications` shortcut side by side in the lower half of the window
+- Exports the final image to `build/bin/AIVectorMemory-darwin-amd64.dmg`
+
+You may also provide custom paths:
+
+```bash
+./build/package_dmg.sh /path/to/AIVectorMemory.app /path/to/output.dmg
+```
 
 ## Windows
 

--- a/desktop/build/package_dmg.sh
+++ b/desktop/build/package_dmg.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${PROJECT_DIR}/.." && pwd)"
+BIN_DIR="${PROJECT_DIR}/build/bin"
+
+APP_NAME="${APP_NAME:-AIVectorMemory}"
+VOLUME_NAME="${VOLUME_NAME:-${APP_NAME}}"
+APP_BUNDLE="${1:-${BIN_DIR}/${APP_NAME}.app}"
+OUTPUT_DMG="${2:-${BIN_DIR}/${APP_NAME}-darwin-amd64.dmg}"
+BACKGROUND_IMAGE="${DMG_BACKGROUND:-}"
+SOURCE_BACKGROUND_IMAGE="${DMG_SOURCE_BACKGROUND:-${REPO_ROOT}/docs/image.png}"
+BACKGROUND_RENDERER="${SCRIPT_DIR}/render_dmg_background.swift"
+
+if [[ ! -d "${APP_BUNDLE}" ]]; then
+  echo "App bundle not found: ${APP_BUNDLE}" >&2
+  echo "Please build the desktop app first, for example:" >&2
+  echo "  /tmp/gopath/bin/wails build -clean -platform darwin/amd64 -m -nosyncgomod" >&2
+  exit 1
+fi
+
+if ! command -v hdiutil >/dev/null 2>&1; then
+  echo "hdiutil is required to package macOS DMG files." >&2
+  exit 1
+fi
+
+STAGING_DIR="$(mktemp -d /tmp/${APP_NAME}.dmg.XXXXXX)"
+STAGING_ROOT="${STAGING_DIR}/root"
+RW_DMG="${STAGING_DIR}/${APP_NAME}-temp.dmg"
+DEVICE=""
+MOUNT_POINT=""
+HAS_BACKGROUND="false"
+
+cleanup() {
+  if [[ -n "${DEVICE}" ]]; then
+    hdiutil detach "${DEVICE}" -quiet >/dev/null 2>&1 || true
+  elif [[ -n "${MOUNT_POINT}" && -d "${MOUNT_POINT}" ]]; then
+    hdiutil detach "${MOUNT_POINT}" -quiet >/dev/null 2>&1 || true
+  fi
+  rm -rf "${STAGING_DIR}"
+}
+trap cleanup EXIT
+
+rm -f "${OUTPUT_DMG}"
+mkdir -p "${STAGING_ROOT}"
+cp -R "${APP_BUNDLE}" "${STAGING_ROOT}/"
+ln -s /Applications "${STAGING_ROOT}/Applications"
+
+if [[ -z "${BACKGROUND_IMAGE}" && -f "${BACKGROUND_RENDERER}" && -f "${SOURCE_BACKGROUND_IMAGE}" ]]; then
+  GENERATED_BACKGROUND_IMAGE="${STAGING_DIR}/dmg-background.png"
+  SWIFT_MODULECACHE_PATH="${SWIFT_MODULECACHE_PATH:-/tmp/swift-module-cache}" \
+  CLANG_MODULE_CACHE_PATH="${CLANG_MODULE_CACHE_PATH:-/tmp/clang-module-cache}" \
+  swift "${BACKGROUND_RENDERER}" \
+    "${SOURCE_BACKGROUND_IMAGE}" \
+    "${GENERATED_BACKGROUND_IMAGE}"
+  BACKGROUND_IMAGE="${GENERATED_BACKGROUND_IMAGE}"
+fi
+
+if [[ -f "${BACKGROUND_IMAGE}" ]]; then
+  mkdir -p "${STAGING_ROOT}/.background"
+  cp "${BACKGROUND_IMAGE}" "${STAGING_ROOT}/.background/$(basename "${BACKGROUND_IMAGE}")"
+  HAS_BACKGROUND="true"
+fi
+
+APP_SIZE_MB="$(du -sm "${APP_BUNDLE}" | awk '{print $1}')"
+DMG_SIZE_MB=$((APP_SIZE_MB + 64))
+
+hdiutil create \
+  -volname "${VOLUME_NAME}" \
+  -srcfolder "${STAGING_ROOT}" \
+  -ov \
+  -format UDRW \
+  -size "${DMG_SIZE_MB}m" \
+  "${RW_DMG}" >/dev/null
+
+ATTACH_OUTPUT="$(hdiutil attach -readwrite -noverify -noautoopen "${RW_DMG}")"
+DEVICE="$(echo "${ATTACH_OUTPUT}" | awk '/^\/dev\// {print $1; exit}')"
+MOUNT_POINT="$(echo "${ATTACH_OUTPUT}" | awk '/\/Volumes\// {mount=$NF} END {print mount}')"
+
+if [[ -z "${DEVICE}" || -z "${MOUNT_POINT}" ]]; then
+  echo "Failed to attach temporary DMG." >&2
+  exit 1
+fi
+
+if command -v osascript >/dev/null 2>&1; then
+  APP_BUNDLE_NAME="$(basename "${APP_BUNDLE}")"
+  BACKGROUND_FILE_NAME="$(basename "${BACKGROUND_IMAGE}")"
+  HAS_BACKGROUND_VALUE="${HAS_BACKGROUND}"
+  osascript <<EOF_APPLESCRIPT >/dev/null
+on run
+  tell application "Finder"
+    tell disk "${VOLUME_NAME}"
+      open
+      set current view of container window to icon view
+      set toolbar visible of container window to false
+      set statusbar visible of container window to false
+      set the bounds of container window to {100, 100, 1508, 868}
+      set theViewOptions to the icon view options of container window
+      set arrangement of theViewOptions to not arranged
+      set icon size of theViewOptions to 140
+      if "${HAS_BACKGROUND_VALUE}" is equal to "true" then
+        set background picture of theViewOptions to file ".background:${BACKGROUND_FILE_NAME}"
+      end if
+      set position of item "${APP_BUNDLE_NAME}" to {280, 500}
+      set position of item "Applications" to {1120, 500}
+      close
+      open
+      update without registering applications
+      delay 2
+    end tell
+  end tell
+end run
+EOF_APPLESCRIPT
+fi
+
+sync
+hdiutil detach "${DEVICE}" -quiet
+DEVICE=""
+MOUNT_POINT=""
+
+hdiutil convert "${RW_DMG}" -format UDZO -imagekey zlib-level=9 -o "${OUTPUT_DMG}" >/dev/null
+
+echo "Created drag-install DMG: ${OUTPUT_DMG}"

--- a/desktop/build/render_dmg_background.swift
+++ b/desktop/build/render_dmg_background.swift
@@ -1,0 +1,37 @@
+import AppKit
+import Foundation
+
+guard CommandLine.arguments.count >= 3 else {
+    fputs("Usage: render_dmg_background.swift <background> <output>\n", stderr)
+    exit(1)
+}
+
+let backgroundPath = CommandLine.arguments[1]
+let outputPath = CommandLine.arguments[2]
+
+guard let background = NSImage(contentsOfFile: backgroundPath) else {
+    fputs("Failed to load background image: \(backgroundPath)\n", stderr)
+    exit(1)
+}
+
+let size = background.size
+let outputImage = NSImage(size: size)
+
+outputImage.lockFocus()
+background.draw(in: NSRect(origin: .zero, size: size), from: .zero, operation: .copy, fraction: 1.0)
+NSColor(calibratedWhite: 1.0, alpha: 0.60).setFill()
+NSBezierPath(rect: NSRect(origin: .zero, size: size)).fill()
+outputImage.unlockFocus()
+
+guard
+    let tiffData = outputImage.tiffRepresentation,
+    let bitmap = NSBitmapImageRep(data: tiffData),
+    let pngData = bitmap.representation(using: .png, properties: [:])
+else {
+    fputs("Failed to render output image.\n", stderr)
+    exit(1)
+}
+
+let outputURL = URL(fileURLWithPath: outputPath)
+try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
+try pngData.write(to: outputURL)


### PR DESCRIPTION
## Summary
- add a reusable macOS drag-install DMG packaging script for the desktop app
- keep the installer window as a standard drag-to-Applications layout
- generate the DMG background directly from `docs/image.png` with a 60% white overlay only
- document the packaging flow in the desktop build docs and record the change in `CHANGELOG.md`

## Motivation
The macOS installer experience should match the common drag-install workflow while keeping the visual treatment simple and consistent with the project assets. This change avoids extra decorative overlays and uses the existing architecture artwork as the only background source.

## Implementation Details
- add `desktop/build/package_dmg.sh` to package `AIVectorMemory.app` into a drag-install DMG
- add `desktop/build/render_dmg_background.swift` to render a derived DMG background image from `docs/image.png`
- place `AIVectorMemory.app` and the `Applications` symlink in the lower half of the Finder window
- keep the DMG generation flow compatible with local Intel macOS builds

## Testing
- `bash -n desktop/build/package_dmg.sh`
- `SWIFT_MODULECACHE_PATH=/tmp/swift-module-cache CLANG_MODULE_CACHE_PATH=/tmp/clang-module-cache swift desktop/build/render_dmg_background.swift /Users/mac/code/aivectormemory/docs/image.png /tmp/aivectormemory-dmg-bg.png`

## Notes
- this PR is based on the latest `upstream/main` at the time of submission
- GitHub currently reports no CI checks for this branch yet